### PR TITLE
Initial block audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,59 @@
-MySQLBase
-===========
-
-Stores input signals in a MySQL database.
-
-Properties
---------------
-
--   **host**: MySQL server host.
--   **port**: MySQL server port.
--   **database**: Database name.
--   **commit_after_query**: Whether or not to issue a commit after a query is executed.
--   **retry_timeout**: When disconnected, this specifies how long to wait before attempting to connect.
-
-Dependencies
-----------------
-
--   [pymysql](https://pypi.python.org/pypi/PyMySQL/)
-
-Commands
-----------------
-None
-
-Input
--------
-None
-
-Output
----------
-None
-
-***
-
 MySQLInsert
 ===========
-
 Stores input signals in a MySQL database.
 
 Properties
---------------
+----------
+- **commit_after_query**: Whether or not to issue a commit after a query is executed.
+- **credentials**: MySQL user name and password to connect to database.
+- **database**: Name of MySQL database to connect to.
+- **host**: MySQL server host.
+- **port**: MySQL server port.
+- **retry_timeout**: When disconnected, this specifies how long to wait before attempting to connect.
+- **target_table**: MySQL table to insert into.  Allows to specify/calculate table name from signal
 
--   **target_table**: Allows to specify/calculate table name from signal
+Inputs
+------
+- **default**: A record will be inserted into the database for each input signal.
 
-Dependencies
-----------------
-
--   [pymysql](https://pypi.python.org/pypi/PyMySQL/)
+Outputs
+-------
+- **default**: A signal containing number of successfully added items.
 
 Commands
-----------------
+--------
 None
 
-Input
--------
-A record will be inserted into the database for each input signal.
-
-Output
----------
-A signal containing number of successfully added items
-
-***
+Dependencies
+------------
+-   [pymysql](https://pypi.python.org/pypi/PyMySQL/)
 
 MySQLQuery
-===========
-
-Queries MySQL database.
+==========
+Queries a MySQL database.
 
 Properties
---------------
+----------
+- **commit_after_query**: Whether or not to issue a commit after a query is executed.
+- **credentials**: MySQL user name and password to connect to database.
+- **database**: Name of MySQL database to connect to.
+- **host**: MySQL server host.
+- **port**: MySQL server port.
+- **query**: SQL query to execute.
+- **retry_timeout**: When disconnected, this specifies how long to wait before attempting to connect.
 
--   **query**: Query statement
+Inputs
+------
+- **default**: Any list of signals.
 
-Dependencies
-----------------
-
--   [pymysql](https://pypi.python.org/pypi/PyMySQL/)
+Outputs
+-------
+- **default**: Data satisfying query in the form of 'Signal' instances.
 
 Commands
-----------------
+--------
 None
 
-Input
--------
-Signals to be processed.
-
-Output
----------
-Data satisfying query in the form of 'Signal' instances.
-
+Dependencies
+------------
+-   [pymysql](https://pypi.python.org/pypi/PyMySQL/)

--- a/mysql_base_block.py
+++ b/mysql_base_block.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
 
 from nio.util.versioning.dependency import DependsOn
+from nio.util.discovery import not_discoverable
 from nio.block.base import Block
 from nio.properties import TimeDeltaProperty, StringProperty, \
     ObjectProperty, IntProperty, PropertyHolder, BoolProperty
 from nio.modules.scheduler import Job
+
 from .driver.mysql import MySQL
 
 
@@ -19,6 +21,7 @@ class Credentials(PropertyHolder):
     password = StringProperty(title='Password', default='[[MYSQL_PASSWORD]]')
 
 
+@not_discoverable
 @DependsOn("nio.modules.scheduler")
 class MySQLBase(Block):
 
@@ -48,7 +51,8 @@ class MySQLBase(Block):
     def configure(self, context):
         super().configure(context)
         self._db = MySQL(self.host(), self.port(), self.database(),
-                         self.credentials().username(), self.credentials().password(),
+                         self.credentials().username(),
+                         self.credentials().password(),
                          self.commit_after_query(),
                          self.logger,
                          target_table=self.get_target_table())
@@ -128,8 +132,8 @@ class MySQLBase(Block):
                 self.logger.debug("Closing connection")
                 self._db.close()
             except Exception as e:
-                self.logger.debug("Failed to close connection, details".
-                                   format(str(e)))
+                self.logger.debug(
+                    "Failed to close connection, details".format(str(e)))
 
     def _reconnect(self):
         self._connection_job = None
@@ -139,8 +143,10 @@ class MySQLBase(Block):
     def _on_discarded_signals(self, signals):
         # TODO, good place to implement functionality for
         # "saving" signals hoping for a reconnect and have no-loss
-        self.logger.warning('Block is not connected, discarding: {0} '
-                             'signals'.format(len(signals)))
+        self.logger.warning(
+            'Block is not connected, discarding: {0} signals'.format(
+                len(signals))
+        )
 
     @property
     def connected(self):

--- a/mysql_insert_block.py
+++ b/mysql_insert_block.py
@@ -1,11 +1,9 @@
-from nio.util.discovery import discoverable
 from nio import Signal
-from nio.properties import Property
+from nio.properties import Property, VersionProperty
 
 from .mysql_base_block import MySQLBase
 
 
-@discoverable
 class MySQLInsert(MySQLBase):
 
     """ A block for inserting data into a MySQL database.
@@ -15,6 +13,7 @@ class MySQLInsert(MySQLBase):
     """
     target_table = Property(
         title='Target table', default="{{($__class__.__name__)}}")
+    version = VersionProperty("0.0.1")
 
     def get_target_table(self):
         return self.target_table()

--- a/mysql_query_block.py
+++ b/mysql_query_block.py
@@ -1,12 +1,9 @@
-from nio.util.discovery import discoverable
-from nio.properties import Property
+from nio.properties import Property, VersionProperty
 from nio.signal.base import Signal
 
 from .mysql_base_block import MySQLBase
-from . import evaluate_expression
 
 
-@discoverable
 class MySQLQuery(MySQLBase):
 
     """ A block for inserting data into a MySQL database.
@@ -15,6 +12,7 @@ class MySQLQuery(MySQLBase):
     """
     query = Property(
         title='Query', default="SELECT * from {{$table}}")
+    version = VersionProperty("0.0.1")
 
     def execute_query(self, signals):
         for signal in signals:

--- a/release.json
+++ b/release.json
@@ -1,17 +1,12 @@
 {
-  "nio/MySQLBase": {
-    "language": "Python",
-    "version": "0.0.1",
-    "url": "git://github.com/nio-blocks/mysql.git"
-  },
   "nio/MySQLInsert": {
     "language": "Python",
-    "version": "0.0.1",
-    "url": "git://github.com/nio-blocks/mysql.git"
+    "url": "git://github.com/nio-blocks/mysql.git",
+    "version": "0.0.1"
   },
   "nio/MySQLQuery": {
     "language": "Python",
-    "version": "0.0.1",
-    "url": "git://github.com/nio-blocks/mysql.git"
+    "url": "git://github.com/nio-blocks/mysql.git",
+    "version": "0.0.1"
   }
 }

--- a/spec.json
+++ b/spec.json
@@ -1,26 +1,130 @@
 {
-  "nio/MySQLBase": {
-    "version": "0.0.1",
-    "description": "",
-    "inputs": {},
-    "outputs": {},
-    "properties": {},
-    "commands": {}
-  },
   "nio/MySQLInsert": {
     "version": "0.0.1",
-    "description": "",
-    "inputs": {},
-    "outputs": {},
-    "properties": {},
+    "description": "Stores input signals in a MySQL database.",
+    "properties": {
+      "commit_after_query": {
+        "title": "Commit After Query",
+        "type": "BoolType",
+        "description": "Whether or not to issue a commit after a query is executed.",
+        "default": false
+      },
+      "credentials": {
+        "title": "Connection Credentials",
+        "type": "ObjectType",
+        "description": "MySQL user name and password to connect to database.",
+        "default": {
+          "password": "[[MYSQL_PASSWORD]]",
+          "username": "[[MYSQL_USER]]"
+        }
+      },
+      "database": {
+        "title": "Database Name",
+        "type": "StringType",
+        "description": "Name of MySQL database to connect to.",
+        "default": "signals"
+      },
+      "host": {
+        "title": "MySQL Host",
+        "type": "StringType",
+        "description": "MySQL server host.",
+        "default": "[[MYSQL_HOST]]"
+      },
+      "port": {
+        "title": "Port",
+        "type": "IntType",
+        "description": "MySQL server port.",
+        "default": 3306
+      },
+      "retry_timeout": {
+        "title": "Retry Timeout",
+        "type": "TimeDeltaType",
+        "description": "When disconnected, this specifies how long to wait before attempting to connect.",
+        "default": {
+          "seconds": 1
+        }
+      },
+      "target_table": {
+        "title": "Target table",
+        "type": "Type",
+        "description": "MySQL table to insert into.  Allows to specify/calculate table name from signal",
+        "default": "{{($__class__.__name__)}}"
+      }
+    },
+    "inputs": {
+      "default": {
+        "description": "A record will be inserted into the database for each input signal."
+      }
+    },
+    "outputs": {
+      "default": {
+        "description": "A signal containing number of successfully added items."
+      }
+    },
     "commands": {}
   },
   "nio/MySQLQuery": {
     "version": "0.0.1",
-    "description": "",
-    "inputs": {},
-    "outputs": {},
-    "properties": {},
+    "description": "Queries a MySQL database.",
+    "properties": {
+      "commit_after_query": {
+        "title": "Commit After Query",
+        "type": "BoolType",
+        "description": "Whether or not to issue a commit after a query is executed.",
+        "default": false
+      },
+      "credentials": {
+        "title": "Connection Credentials",
+        "type": "ObjectType",
+        "description": "MySQL user name and password to connect to database.",
+        "default": {
+          "password": "[[MYSQL_PASSWORD]]",
+          "username": "[[MYSQL_USER]]"
+        }
+      },
+      "database": {
+        "title": "Database Name",
+        "type": "StringType",
+        "description": "Name of MySQL database to connect to.",
+        "default": "signals"
+      },
+      "host": {
+        "title": "MySQL Host",
+        "type": "StringType",
+        "description": "MySQL server host.",
+        "default": "[[MYSQL_HOST]]"
+      },
+      "port": {
+        "title": "Port",
+        "type": "IntType",
+        "description": "MySQL server port.",
+        "default": 3306
+      },
+      "query": {
+        "title": "Query",
+        "type": "Type",
+        "description": "SQL query to execute.",
+        "default": "SELECT * from {{$table}}"
+      },
+      "retry_timeout": {
+        "title": "Retry Timeout",
+        "type": "TimeDeltaType",
+        "description": "When disconnected, this specifies how long to wait before attempting to connect.",
+        "default": {
+          "seconds": 1
+        }
+      }
+    },
+    "inputs": {
+      "default": {
+        "description": "Any list of signals."
+      }
+    },
+    "outputs": {
+      "default": {
+        "description": "Data satisfying query in the form of 'Signal' instances."
+      }
+    },
     "commands": {}
   }
 }

--- a/tests/driver/test_mysql.py
+++ b/tests/driver/test_mysql.py
@@ -1,4 +1,10 @@
+import unittest
+import logging
+from datetime import datetime
+
 from nio import Signal
+from nio.util.threading import spawn
+
 # TODO, set this to False by default
 from ...driver.mysql import MySQL
 
@@ -12,12 +18,6 @@ try:
 except:
     skip_tests = True
     reason = "pymysql is not installed"
-
-from datetime import datetime
-import unittest
-import logging
-
-from nio.util.threading import spawn
 
 
 class AttributeTypes(object):

--- a/tests/test_mysql_base_block.py
+++ b/tests/test_mysql_base_block.py
@@ -1,9 +1,11 @@
 import logging
 from nio.signal.base import Signal
 from threading import Event
-
 from unittest.mock import Mock
+
 from nio.testing.block_test_case import NIOBlockTestCase
+from nio.util.discovery import not_discoverable
+
 from ..mysql_base_block import MySQLBase
 
 
@@ -13,6 +15,7 @@ class MySQLLikeException(Exception):
         super().__init__("Could not connect to MySQL")
 
 
+@not_discoverable
 class MySQLBaseWithConnect(MySQLBase):
 
     def __init__(self, e, retries=1):


### PR DESCRIPTION
`test_mysql.py` in the Driver directory uses an old style of mocking imports.  If you feel I should switch it to how we now mock the imports in `SetUp` I happily will!